### PR TITLE
Update app.json, volumeChanged -> type to number

### DIFF
--- a/app.json
+++ b/app.json
@@ -206,11 +206,12 @@
 				"tokens": [
 				{
 					"name": "volume",
+					"type": "number",
 					"title": {
 						"en": "Volume",
 						"nl": "Volume"
 					},
-					"example": "18"
+					"example": 18
 				}
 				],
 				"args": [


### PR DESCRIPTION
Hi,

the columeChanged card is called with "volume": [type=number]
the card itself doesnt have a type given and thus the default string type is used. therefor the card doesn't work.
Adding type and change the example accordingly fixes the issue.